### PR TITLE
Feature/thrifty 3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+0.8.0 (released - April 2022)
+------------------
+The major update in this release is the transition of Thrifty to the latest 3.0.0
+
+- `thrifty-compiler` and `thrifty-runtime` version updated to `3.0.0`
+- Following Arguments were updated to compatible with the new version
+- `--generated-annotation-type` is no longer supported by the `thrifty-compiler`
+- `--lang=java` was added to generate the java source (Thrifty generates Kotlin code by default)
+- All unittests related to `@Generated` annotations has been removed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.timvlaer</groupId>
   <artifactId>thrifty-maven-plugin</artifactId>
-  <version>0.7.1</version>
+  <version>0.8.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Thrifty Maven Plugin</name>
@@ -38,7 +38,7 @@
 
     <maven.version>3.6.3</maven.version>
 
-    <thrifty.version>2.1.2</thrifty.version>
+    <thrifty.version>3.0.0</thrifty.version>
 
     <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
     <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>

--- a/src/main/java/com/github/timvlaer/thrifty/ThriftyCompilerMojo.java
+++ b/src/main/java/com/github/timvlaer/thrifty/ThriftyCompilerMojo.java
@@ -42,14 +42,7 @@ public class ThriftyCompilerMojo extends AbstractMojo {
 
     List<String> arguments = new ArrayList<>();
 
-    String compilerReleaseVersion = (String) project.getProperties().get("maven.compiler.release");
-    if (compilerReleaseVersion != null) {
-      getLog().info("maven.compiler.release property is set to " + compilerReleaseVersion);
-      if (Integer.parseInt(compilerReleaseVersion) >= 9) {
-        arguments.add("--generated-annotation-type=jdk9");
-      }
-    }
-
+    arguments.add("--lang=java"); //Thrifty generates Kotlin code by default
     arguments.add("--out=" + outputDirectory);
     arguments.addAll(entryThriftFiles);
     getLog().debug("Run thrifty compiler with following arguments: " + arguments);

--- a/src/main/java/com/github/timvlaer/thrifty/plugin/TaggedUnionMethodTypeProcessor.java
+++ b/src/main/java/com/github/timvlaer/thrifty/plugin/TaggedUnionMethodTypeProcessor.java
@@ -85,7 +85,7 @@ public class TaggedUnionMethodTypeProcessor implements TypeProcessor {
   }
 
   private Boolean wasThriftUnion(TypeSpec type) {
-    return type.superinterfaces.contains(ClassName.get(com.microsoft.thrifty.Struct.class))
+    return type.superinterfaces.contains(ClassName.get("com.microsoft.thrifty", "Struct"))
         && type.typeSpecs.stream()
             .filter(e -> BUILDER_CLASS_NAME.equals(e.name))
             .findFirst()

--- a/src/test/java/com/github/timvlaer/thrifty/ThriftyCompilerMojoTest.java
+++ b/src/test/java/com/github/timvlaer/thrifty/ThriftyCompilerMojoTest.java
@@ -37,7 +37,6 @@ public class ThriftyCompilerMojoTest {
   @Before
   public void setUp() {
     when(project.getBuild()).thenReturn(build);
-    when(project.getProperties()).thenReturn(new Properties());
     when(build.getOutputDirectory())
         .thenReturn(outputFolder.getRoot().getAbsolutePath() + "/classes");
     mojo.setProject(project);
@@ -57,22 +56,7 @@ public class ThriftyCompilerMojoTest {
 
     String result = new String(Files.readAllBytes(resultFile.toPath()), UTF_8);
     assertThat(result).contains("package com.sentiance.thrift;");
-    assertThat(result).contains("import javax.annotation.Generated;"); // java 8
     assertThat(result).contains("public final class LocationFix implements Struct");
-  }
-
-  @Test
-  public void executeWithJava11() throws Exception {
-    Properties properties = new Properties();
-    properties.setProperty("maven.compiler.release", "11");
-    when(project.getProperties()).thenReturn(properties);
-    mojo.setThriftFiles(new File[] {new File("src/test/resources/testcase.thrift")});
-
-    mojo.execute();
-
-    File resultFile = new File(outputFolder.getRoot(), "com/sentiance/thrift/LocationFix.java");
-    String result = new String(Files.readAllBytes(resultFile.toPath()), UTF_8);
-    assertThat(result).contains("import javax.annotation.processing.Generated;"); // java 9
   }
 
   @Test


### PR DESCRIPTION
The major update in this release is the transition of Thrifty to the latest 3.0.0

- `thrifty-compiler` and `thrifty-runtime` version updated to `3.0.0`
- Following Arguments were updated to compatible with the new version
- `--generated-annotation-type` is no longer supported by the `thrifty-compiler`
- `--lang=java` was added to generate the java source (Thrifty generates Kotlin code by default)
- All unittests related to `@Generated` annotations has been removed